### PR TITLE
Add constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,16 +12,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "boehm_reals"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "num-bigint",
- "num-traits",
+ "once_cell",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "num-bigint"
@@ -50,3 +43,9 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,8 +12,16 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "boehm_reals"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "num-bigint",
+ "num-traits",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "num-bigint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2024"
 
 [dependencies]
 num-bigint = "0.4"
+num-traits = "0.2"
+lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,4 @@ edition = "2024"
 
 [dependencies]
 num-bigint = "0.4"
-num-traits = "0.2"
-lazy_static = "1.4"
+once_cell = "1"

--- a/src/bounded_rational.rs
+++ b/src/bounded_rational.rs
@@ -1,5 +1,5 @@
-use num_bigint::BigInt;
 use lazy_static::lazy_static;
+use num_bigint::BigInt;
 
 /*------------- Primitive constants -------------- */
 pub const MAX_SIZE: u32 = 10_000;

--- a/src/bounded_rational.rs
+++ b/src/bounded_rational.rs
@@ -1,26 +1,51 @@
-use lazy_static::lazy_static;
 use num_bigint::BigInt;
+use once_cell::sync::Lazy;
 
-/*------------- Primitive constants -------------- */
-pub const MAX_SIZE: u32 = 10_000;
+/// Maximum combined bit length of numerator and denominator.
+/// If `numerator.bits() + denominator.bits()` exceeds this value,
+/// the rational is considered too large to be useful and `None` is returned
+/// by arithmetic operations instead of a reduced result.
+pub const MAX_SIZE: usize = 10_000;
 
-/*---------- BigInt constants ----------------- */
-lazy_static! {
-    // Core numeric sentinels used as fast-return shortcuts throughout the crate
-    pub static ref ZERO:      BigInt = BigInt::from(0i32);
-    pub static ref ONE:       BigInt = BigInt::from(1i32);
-    pub static ref MINUS_ONE: BigInt = BigInt::from(-1i32);
-    pub static ref TWO:       BigInt = BigInt::from(2i32);
-    pub static ref MINUS_TWO: BigInt = BigInt::from(-2i32);
-    pub static ref TEN:       BigInt = BigInt::from(10i32);
+/// Additive identity. Returned directly when a result is exactly zero.
+pub static ZERO: Lazy<BigInt> = Lazy::new(|| BigInt::from(0i32));
 
-    // Used in reduction / GCD short-circuit paths
-    pub static ref BIG_FIVE:  BigInt = BigInt::from(5i32);
-}
+/// Multiplicative identity. Used as a fast-return shortcut in multiplication.
+pub static ONE: Lazy<BigInt> = Lazy::new(|| BigInt::from(1i32));
 
-/*----------- Struct ---------------- */
+/// Negative one. Used in negation and sign-check shortcuts.
+pub static MINUS_ONE: Lazy<BigInt> = Lazy::new(|| BigInt::from(-1i32));
+
+/// Two. Used in halving, doubling, and base-2 termination checks.
+pub static TWO: Lazy<BigInt> = Lazy::new(|| BigInt::from(2i32));
+
+/// Negative two. Used in sign-aware doubling shortcuts.
+pub static MINUS_TWO: Lazy<BigInt> = Lazy::new(|| BigInt::from(-2i32));
+
+/// Ten. Used in base-10 scaling and decimal conversion.
+pub static TEN: Lazy<BigInt> = Lazy::new(|| BigInt::from(10i32));
+
+/// Used in base-10 termination checks - a decimal terminates
+/// if and only if the reduced denominator has no prime factors other than 2 and 5.
+pub static FIVE: Lazy<BigInt> = Lazy::new(|| BigInt::from(5i32));
+
+/// A ratio of two arbitrary-precision integers, `numerator/denominator`
+///
+/// Arithmetic operations return `None` when the result would exceed
+/// [`MAX_SIZE`] combined bits, signalling the caller to fall back to
+/// a constructive-real approximation. All values are treated as exact
+/// until that point.
+///
+/// # Invariants
+/// - The denominator is never zero.
+/// - Fractions are not always fully reduced; simplification happens
+///   occasionally at random to avoid paying the cost of GCD on every
+///   operation.
+
 #[derive(Clone, Debug)]
 pub struct BoundedRational {
+    /// The top half of the fraction.
     pub numerator: BigInt,
+    /// The bottom half of the fraction. Must never be zero.
     pub denominator: BigInt,
 }

--- a/src/bounded_rational.rs
+++ b/src/bounded_rational.rs
@@ -1,5 +1,24 @@
 use num_bigint::BigInt;
+use lazy_static::lazy_static;
 
+/*------------- Primitive constants -------------- */
+pub const MAX_SIZE: u32 = 10_000;
+
+/*---------- BigInt constants ----------------- */
+lazy_static! {
+    // Core numeric sentinels used as fast-return shortcuts throughout the crate
+    pub static ref ZERO:      BigInt = BigInt::from(0i32);
+    pub static ref ONE:       BigInt = BigInt::from(1i32);
+    pub static ref MINUS_ONE: BigInt = BigInt::from(-1i32);
+    pub static ref TWO:       BigInt = BigInt::from(2i32);
+    pub static ref MINUS_TWO: BigInt = BigInt::from(-2i32);
+    pub static ref TEN:       BigInt = BigInt::from(10i32);
+
+    // Used in reduction / GCD short-circuit paths
+    pub static ref BIG_FIVE:  BigInt = BigInt::from(5i32);
+}
+
+/*----------- Struct ---------------- */
 #[derive(Clone, Debug)]
 pub struct BoundedRational {
     pub numerator: BigInt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,18 @@
+//! Boehm-style arbitrary-precision real arithmetic.
+//!
+//! This crate implements exact real arithmetic using two complementory
+//! representations:
+//!
+//! - Bounded Rational
+//! - Constructive reals
+
+#![deny(missing_docs)]
+
+/// Arbitrary-precision rational arithmetic with a bounded size budget.
+///
+/// [`bounded_rational::BoundedRational`] represents exact rational numbers
+/// as `numerator/denominator` pairs of [`num_bigint::BigInt`]s. Operations
+/// return `None` once the combined bit length exceeds
+/// [`bounded_rational::MAX_SIZE`], at which point the caller is expected
+/// to fall back to constructive-real (`CR`) approximation.
 pub mod bounded_rational;


### PR DESCRIPTION
Issue #2 
REDUCE_RNG — Deferred to the reduction issue

Decided not to add REDUCE_RNG as a global static for now.

The original plan was to store a shared RNG in lazy_static! for probabilistic reduction. However, this caused a compile error because ThreadRng is not thread-safe and cannot live in a global static.

The fix would have been to use StdRng instead, but that adds unnecessary complexity (Mutex, SeedableRng) for something that doesn't need to be global at all.

Decision: Will use rand::thread_rng() locally inside the reduction method when that issue is implemented. It has no performance cost since thread_rng() is already cached per thread under the hood.